### PR TITLE
ci:  fix release ci to make the ios example use the updated rn sdk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   authorize: 
     name: Authorize
-    runs-on: ubuntu-18.04 
+    runs-on: macos-10.15 
     steps:
       - name: ${{ github.actor }} permission check to do a release
         uses: octokit/request-action@v2.0.0
@@ -22,8 +22,12 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-18.04 
+    runs-on: macos-10.15
     needs: [authorize]
+    strategy:
+      matrix:
+        ruby-version: ["2.7.x"]
+        node-version: ["12.x"]
     env:
       GIT_AUTHOR_NAME: amplitude-sdk-bot
       GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
@@ -32,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v2
 
       - name: node_modules cache
         uses: actions/cache@v2
@@ -43,13 +47,33 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 12.x
+          node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
       - name: Build
         run: yarn prepare
+
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Cache Bundle Gems and Cocoapods
+        id: cache-gems-pods
+        uses: actions/cache@v2
+        with:
+          path: |
+            Pods
+            vendor/bundle
+          key: ${{ runner.os }}-ruby-${{ matrix.ruby-version }}-gems-${{ hashFiles('**/Gemfile.lock') }}-pods-${{ hashFiles('**/Podfile.lock') }}
+
+      - name: Install Cocoapods
+        if: steps.cache-gems-pods.outputs.cache-hit != 'true'
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
 
       - name: Release --dry-run  # Uses release.config.js
         if: ${{ github.event.inputs.dryRun == 'true'}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
     strategy:
       matrix:
         ruby-version: ["2.7.x"]
-        node-version: ["12.x"]
     env:
       GIT_AUTHOR_NAME: amplitude-sdk-bot
       GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
@@ -47,7 +46,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 12.x
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "prepare": "bob build",
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",
+    "update-example-pod-lockfile": "yarn example install --frozen-lockfile && yarn pods",
     "bootstrap": "yarn example && yarn && yarn pods",
     "docs:create-docs": "typedoc --tsconfig ./tsconfig.build.json --theme './node_modules/typedoc-neo-theme'",
     "docs:gen-docs": "rm -rf docs && yarn run docs:create-docs && git add docs",

--- a/release.config.js
+++ b/release.config.js
@@ -47,8 +47,7 @@ module.exports = {
     [
       '@semantic-release/exec',
       {
-        prepareCmd:
-          'cd example &&  yarn install --frozen-lockfile && cd ios && pod install',
+        prepareCmd: 'yarn update-example-pod-lockfile',
       },
     ],
     [

--- a/release.config.js
+++ b/release.config.js
@@ -45,9 +45,21 @@ module.exports = {
       },
     ],
     [
+      '@semantic-release/exec',
+      {
+        prepareCmd:
+          'cd example &&  yarn install --frozen-lockfile && cd ios && pod install',
+      },
+    ],
+    [
       '@semantic-release/git',
       {
-        assets: ['docs', 'package.json', 'src/constants.ts'],
+        assets: [
+          'docs',
+          'package.json',
+          'src/constants.ts',
+          'example/ios/Podfile.lock',
+        ],
         message:
           'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
       },


### PR DESCRIPTION
Install the cocoapods before `yarn release`.
run `pod install` in example/ios after we updated the rn SDK version during the release progress.