### PR TITLE
chore: correct setUserId typing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ export class Amplitude {
    *
    * @param userId
    */
-  setUserId(userId: string): Promise<boolean> {
+  setUserId(userId: string | null): Promise<boolean> {
     return AmplitudeReactNative.setUserId(this.instanceName, userId);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ export interface AmplitudeReactNativeModule {
     instanceName: string,
     useDynamicConfig: boolean,
   ): Promise<boolean>;
-  setUserId(instanceName: string, userId: string): Promise<boolean>;
+  setUserId(instanceName: string, userId: string | null): Promise<boolean>;
   setServerUrl(instanceName: string, serverUrl: string): Promise<boolean>;
   logRevenueV2(
     instanceName: string,


### PR DESCRIPTION
From this repo's [`CONTRIBUTING.md`](https://github.com/amplitude/Amplitude-ReactNative/blob/b8fa1573e199c8acace2426ef170e16f0ed1db00/CONTRIBUTING.md):

> Follow the pull request template when opening a pull request.

I couldn't find a PR template though, so I took the one from [`amplitude-js`](https://raw.githubusercontent.com/amplitude/Amplitude-JavaScript/main/.github/pull_request_template.md).

<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

The Amplitude docs for the [Android SDK](https://raw.githubusercontent.com/amplitude/Amplitude-JavaScript/main/.github/pull_request_template.md), [iOS SDK](https://developers.amplitude.com/docs/ios#log-out-and-anonymous-users) and [Javascript SDK](https://developers.amplitude.com/docs/javascript#log-out-and-anonymous-users) mention it's possible to register a logout by calling `setUserId(null)` or `setUserId(nil)`.

From the fact that this repository uses the Android & iOS SDK under the hood, the react native part should also be able to digest `setUserId(null)`.

I've been using this in my own RN app (using `@ts-ignore`) and can confirm this works.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No