### PR TITLE
fix: move @semantic-release/exec to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@react-native-community/eslint-config": "^2.0.0",
     "@release-it/conventional-changelog": "^2.0.1",
     "@semantic-release/commit-analyzer": "^8.0.1",
+    "@semantic-release/exec": "^5.0.0",
     "@semantic-release/git": "^9.0.0",
     "@semantic-release/github": "^7.2.0",
     "@semantic-release/npm": "^7.0.10",
@@ -132,8 +133,5 @@
         }
       ]
     ]
-  },
-  "dependencies": {
-    "@semantic-release/exec": "^5.0.0"
   }
 }


### PR DESCRIPTION
After releasing 2.3.1, I noticed we are including `@semantic-release/exec` as a dependency in the bundle that users get when installing.  Since this dependency is purely CI related, users should not have to install this package as it is providing no value to them.

This PR moves `@semantic-release/exec` out of `dependencies` and into `devDependencies`