### PR TITLE
fix: Change build.gradle to use correct key prop for rootProject.ext

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,11 +18,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('ReactNative_compileSdkVersion', 29)
-    buildToolsVersion safeExtGet('ReactNative_buildToolsVersion', '29.0.2')
+    compileSdkVersion safeExtGet('compileSdkVersion', 29)
+    buildToolsVersion safeExtGet('buildToolsVersion', '29.0.2')
     defaultConfig {
-        minSdkVersion safeExtGet('ReactNative_minSdkVersion', 16)
-        targetSdkVersion safeExtGet('ReactNative_targetSdkVersion', 29)
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 29)
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
The current prop for the compileSdkVersion, buildToolsVersion, minSdkVersion and targetSdkVersion are wrong.
Only the fallback is taken at each build.

Fix to be able to `gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug` for Detox to work