### PR TITLE
fix: remove double-quoted imports from React-Core

### DIFF
--- a/ios/AmplitudeReactNative-Bridging-Header.h
+++ b/ios/AmplitudeReactNative-Bridging-Header.h
@@ -1,5 +1,1 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif


### PR DESCRIPTION
according to https://github.com/expo/expo/issues/15622#issuecomment-997225774, please help to remove the double-quoted imports which break swift integration and they're only for react-native < 0.40. 