### PR TITLE
feat: Add versionId to tracking plan data

### DIFF
--- a/amplitude-react-native.podspec
+++ b/amplitude-react-native.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Amplitude", "8.8.0"
+  s.dependency "Amplitude", "8.10.0"
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,5 +55,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation "com.amplitude:android-sdk:2.36.1"
+    implementation "com.amplitude:android-sdk:2.37.0"
 }

--- a/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeModule.java
+++ b/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeModule.java
@@ -323,6 +323,9 @@ public class AmplitudeReactNativeModule extends ReactContextBaseJavaModule {
         if (planProperties.hasKey("version")) {
             plan.setVersion(planProperties.getString("version"));
         }
+        if (planProperties.hasKey("versionId")) {
+            plan.setVersionId(planProperties.getString("versionId"));
+        }
 
         AmplitudeClient client = Amplitude.getInstance(instanceName);
         synchronized (client) {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - Amplitude (8.8.0):
+  - Amplitude (8.10.0):
     - AnalyticsConnector (~> 1.0.0)
   - amplitude-react-native (2.10.0):
-    - Amplitude (= 8.8.0)
+    - Amplitude (= 8.10.0)
     - React-Core
   - AnalyticsConnector (1.0.0)
   - boost-for-react-native (1.63.0)
@@ -357,8 +357,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Amplitude: 710116f3539c225e86fb70a8abdcd20015683132
-  amplitude-react-native: 0e7ad3adcea6e9e211f6e227d4ee7dd4d83d3f1b
+  Amplitude: 2904f346250510b9e19a4e2262017bcf1d4368f9
+  amplitude-react-native: 5df352ae36a618cd2dc5a11a3639a336d294831b
   AnalyticsConnector: 4c386d5972ac9da86e22d668564dbbac97558754
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cde416483dac037923206447da6e1454df403714

--- a/example/src/utils/amplitude.tsx
+++ b/example/src/utils/amplitude.tsx
@@ -12,6 +12,7 @@ const initAmplitude = (): Amplitude => {
     branch: 'example-branch',
     source: 'example-source',
     version: '1.2.3',
+    versionId: 'example-version-id',
   });
 
   amplitudeInstance.addEventMiddleware((payload, next) => {

--- a/ios/AmplitudeReactNative.swift
+++ b/ios/AmplitudeReactNative.swift
@@ -290,6 +290,9 @@ class ReactNative: NSObject {
         if (planProperties["version"] != nil) {
             plan.setVersion(planProperties["version"] as! String)
         }
+        if (planProperties["versionId"] != nil) {
+            plan.setVersionId(planProperties["versionId"] as! String)
+        }
         Amplitude.instance(withName: instanceName).setPlan(plan)
         resolve(true)
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,4 +164,6 @@ export type Plan = {
   source?: string;
   /** The tracking plan version e.g. "1", "15" */
   version?: string;
+  /** The tracking plan version Id e.g. "9ec23ba0-275f-468f-80d1-66b88bff9529" */
+  versionId?: string;
 };


### PR DESCRIPTION
1. not tested on iOS
2. `example/ios/Podfile.lock` is not updated to bump versions
