### PR TITLE
feat: enable to call setAdvertisingIdForDeviceId in iOS

### DIFF
--- a/ios/AmplitudeReactNative.swift
+++ b/ios/AmplitudeReactNative.swift
@@ -60,7 +60,7 @@ class ReactNative: NSObject {
     func setAdvertisingIdForDeviceId(_ instanceName: String,
                             resolver resolve: RCTPromiseResolveBlock,
                             rejecter reject: RCTPromiseRejectBlock) -> Void {
-        resolve(false)
+        resolve(Amplitude.instance(withName: instanceName).useAdvertisingIdForDeviceId())
     }
 
     @objc


### PR DESCRIPTION
This pr is about enable to call useAdvertisingIdForDeviceId in iOS.

In order to use idfv as a device Id. We need to implement the adSupportBlock in iOS natvie. And also need to call useAdvertisingIdForDeviceId based on [here](https://github.com/amplitude/Amplitude-iOS/blob/main/Sources/Amplitude/Amplitude.m#L1539). Since the default _useAdvertisingIdForDeviceId value in iOS is false. So we need to add this ability in Reatnative to set the _useAdvertisingIdForDeviceId to true.

