### PR TITLE
fix: handle null from getDeviceId()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ export class Amplitude {
    * Fetches the deviceId, a unique identifier shared between multiple users using the same app on the same device.
    * @returns the deviceId.
    */
-  getDeviceId(): Promise<string> {
+  getDeviceId(): Promise<string | null> {
     return AmplitudeReactNative.getDeviceId(this.instanceName);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export interface AmplitudeReactNativeModule {
   disableCoppaControl(instanceName: string): Promise<boolean>;
   regenerateDeviceId(instanceName: string): Promise<boolean>;
   setDeviceId(instanceName: string, deviceId: string): Promise<boolean>;
-  getDeviceId(instanceName: string): Promise<string>;
+  getDeviceId(instanceName: string): Promise<string | null>;
   setAdvertisingIdForDeviceId(instanceName: string): Promise<boolean>;
   setAppSetIdForDeviceId(instanceName: string): Promise<boolean>;
   setOptOut(instanceName: string, optOut: boolean): Promise<boolean>;


### PR DESCRIPTION
Update TS interface to have `getDeviceId(): Promise<string|null>`

Since in Java `String` can be `null` and I think the casting to a `string` might be the root cause of the linked issue.