### PR TITLE
feat: add ingestion_metadata field

### DIFF
--- a/amplitude-react-native.podspec
+++ b/amplitude-react-native.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Amplitude", "8.10.0"
+  s.dependency "Amplitude", "8.10.0" # TODO(marvin): need to update after iOS SDK change is merged and released
 end

--- a/amplitude-react-native.podspec
+++ b/amplitude-react-native.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Amplitude", "8.10.0" # TODO(marvin): need to update after iOS SDK change is merged and released
+  s.dependency "Amplitude", "8.13.0"
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,5 +55,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation "com.amplitude:android-sdk:2.37.0"
+    implementation "com.amplitude:android-sdk:2.37.0" // TODO(marvin): need to update after android SDK change is merged and released
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,5 +55,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation "com.amplitude:android-sdk:2.37.0" // TODO(marvin): need to update after android SDK change is merged and released
+    implementation "com.amplitude:android-sdk:2.38.2"
 }

--- a/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeModule.java
+++ b/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeModule.java
@@ -336,14 +336,14 @@ public class AmplitudeReactNativeModule extends ReactContextBaseJavaModule {
             promise.resolve(true);
         }
     }
-    
+
     @ReactMethod
     public void setIngestionMetadata(String instanceName, ReadableMap ingestionMetadataProperties, Promise promise) {
         IngestionMetadata ingestionMetadata = new IngestionMetadata();
-        if (properties.hasKey("sourceName")) {
+        if (ingestionMetadataProperties.hasKey("sourceName")) {
             ingestionMetadata.setSourceName(ingestionMetadataProperties.getString("sourceName"));
         }
-        if (properties.hasKey("sourceVersion")) {
+        if (ingestionMetadataProperties.hasKey("sourceVersion")) {
             ingestionMetadata.setSourceVersion(ingestionMetadataProperties.getString("sourceVersion"));
         }
 

--- a/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeModule.java
+++ b/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeModule.java
@@ -341,10 +341,10 @@ public class AmplitudeReactNativeModule extends ReactContextBaseJavaModule {
     public void setIngestionMetadata(String instanceName, ReadableMap ingestionMetadataProperties, Promise promise) {
         IngestionMetadata ingestionMetadata = new IngestionMetadata();
         if (properties.hasKey("sourceName")) {
-            ingestionMetadata.setBranch(ingestionMetadataProperties.getString("sourceName"));
+            ingestionMetadata.setSourceName(ingestionMetadataProperties.getString("sourceName"));
         }
         if (properties.hasKey("sourceVersion")) {
-            ingestionMetadata.setSource(ingestionMetadataProperties.getString("sourceVersion"));
+            ingestionMetadata.setSourceVersion(ingestionMetadataProperties.getString("sourceVersion"));
         }
 
         AmplitudeClient client = Amplitude.getInstance(instanceName);

--- a/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeModule.java
+++ b/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeModule.java
@@ -8,6 +8,7 @@ import com.amplitude.api.AmplitudeLogCallback;
 import com.amplitude.api.AmplitudeServerZone;
 import com.amplitude.api.Identify;
 import com.amplitude.api.Plan;
+import com.amplitude.api.IngestionMetadata;
 import com.amplitude.api.Revenue;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -332,6 +333,23 @@ public class AmplitudeReactNativeModule extends ReactContextBaseJavaModule {
         AmplitudeClient client = Amplitude.getInstance(instanceName);
         synchronized (client) {
             client.setPlan(plan);
+            promise.resolve(true);
+        }
+    }
+    
+    @ReactMethod
+    public void setIngestionMetadata(String instanceName, ReadableMap ingestionMetadataProperties, Promise promise) {
+        IngestionMetadata ingestionMetadata = new IngestionMetadata();
+        if (properties.hasKey("sourceName")) {
+            ingestionMetadata.setBranch(ingestionMetadataProperties.getString("sourceName"));
+        }
+        if (properties.hasKey("sourceVersion")) {
+            ingestionMetadata.setSource(ingestionMetadataProperties.getString("sourceVersion"));
+        }
+
+        AmplitudeClient client = Amplitude.getInstance(instanceName);
+        synchronized (client) {
+            client.setIngestionMetadata(ingestionMetadata);
             promise.resolve(true);
         }
     }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - Amplitude (8.10.0):
+  - Amplitude (8.13.0):
     - AnalyticsConnector (~> 1.0.0)
   - amplitude-react-native (2.14.0):
-    - Amplitude (= 8.10.0)
+    - Amplitude (= 8.13.0)
     - React-Core
   - AnalyticsConnector (1.0.0)
   - boost-for-react-native (1.63.0)
@@ -357,8 +357,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Amplitude: 2904f346250510b9e19a4e2262017bcf1d4368f9
-  amplitude-react-native: 78644d1cbd188fb4bf6d3625fb6bede0ebdbb989
+  Amplitude: 0a239d682bc9ec1eb7a7b318af2541130ecd4bd3
+  amplitude-react-native: 84fb77a7f064262830e66ed2e1e0c4c4c8c7c9a3
   AnalyticsConnector: 4c386d5972ac9da86e22d668564dbbac97558754
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cde416483dac037923206447da6e1454df403714

--- a/ios/AmplitudeReactNative.m
+++ b/ios/AmplitudeReactNative.m
@@ -64,6 +64,8 @@ RCT_EXTERN_METHOD(setEventUploadThreshold:(NSString *)instanceName eventUploadTh
 
 RCT_EXTERN_METHOD(setPlan:(NSString *)instanceName planProperties:(NSDictionary *)planProperties resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(setIngestionMetadata:(NSString *)instanceName ingestionMetadataProperties:(NSDictionary *)ingestionMetadataProperties resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(enableLogging:(NSString *)instanceName enableLogging:(BOOL *)enableLogging resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(setLogCallback:(NSString *)instanceName callback:(RCTResponseSenderBlock)callback)

--- a/ios/AmplitudeReactNative.swift
+++ b/ios/AmplitudeReactNative.swift
@@ -298,6 +298,22 @@ class ReactNative: NSObject {
     }
 
     @objc
+    func setIngestionMetadata(_ instanceName: String,
+                    ingestionMetadataProperties: [String: Any],
+                    resolver resolve: RCTPromiseResolveBlock,
+                    rejecter reject: RCTPromiseRejectBlock) -> Void {
+        let ingestionMetadata = AMPIngestionMetadata()
+        if (ingestionMetadataProperties["sourceName"] != nil) {
+            ingestionMetadata.setSourceName(ingestionMetadataProperties["sourceName"] as! String)
+        }
+        if (ingestionMetadataProperties["sourceVersion"] != nil) {
+            ingestionMetadata.setSourceVersion(ingestionMetadataProperties["sourceVersion"] as! String)
+        }
+        Amplitude.instance(withName: instanceName).setIngestionMetadata(ingestionMetadata)
+        resolve(true)
+    }
+
+    @objc
     func enableLogging(_ instanceName: String,
                     enableLogging: Bool,
                     resolver resolve: RCTPromiseResolveBlock,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   MiddlewareExtra,
   SpecialEventType,
   Plan,
+  IngestionMetadata,
 } from './types';
 import { MiddlewareRunner } from './middlewareRunner';
 
@@ -30,6 +31,7 @@ export {
   IdentifyPayload,
   IdentifyOperation,
   Plan,
+  IngestionMetadata,
 };
 
 export class Amplitude {
@@ -451,6 +453,15 @@ export class Amplitude {
    */
   setPlan(plan: Plan): Promise<boolean> {
     return AmplitudeReactNative.setPlan(this.instanceName, plan);
+  }
+
+  /**
+   * Sets ingestion metadata information.
+   *
+   * @param ingestionMetadata IngestionMetadata object
+   */
+  setIngestionMetadata(ingestionMetadata: IngestionMetadata): Promise<boolean> {
+    return AmplitudeReactNative.setIngestionMetadata(this.instanceName, ingestionMetadata);
   }
 
   addEventMiddleware(middleware: Middleware): Amplitude {

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,7 @@ export interface AmplitudeReactNativeModule {
     eventUploadThreshold: number,
   ): Promise<boolean>;
   setPlan(instanceName: string, plan: Plan): Promise<boolean>;
+  setIngestionMetadata(instanceName: string, ingestionMetadata: IngestionMetadata): Promise<boolean>;
   enableLogging(instanceName: string, enableLogging: boolean): Promise<boolean>;
   setLogCallback(instanceName: string, callback: Function): void;
   setLogLevel(instanceName: string, logLevel: number): Promise<boolean>;
@@ -169,4 +170,14 @@ export type Plan = {
   version?: string;
   /** The tracking plan version Id e.g. "9ec23ba0-275f-468f-80d1-66b88bff9529" */
   versionId?: string;
+};
+
+/**
+ * Ingestion metadata
+ */
+export type IngestionMetadata = {
+  /** The source name of ingestion metadata e.g. "ampli" */
+  sourceName?: string;
+  /** The source version of ingestion metadata e.g. "2.0.0" */
+  sourceVersion?: string;
 };


### PR DESCRIPTION
### Summary
- feat: add ingestion_metadata field

Add this option in the configuration, which can be used in the library wrapper/code generation/dynamic loading cases, for setting the `ingestion_metadata` information.

No need to add to example as this field in internal measurement usage only.

### Todo
- [x] Bump up the Android SDK version after code in Android repo is merged and released
- [x] Bump up the iOS SDK version after code in iOS repo is merged and released