### PR TITLE
feat: send an error instead of calling a callback from native code

### DIFF
--- a/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeModule.java
+++ b/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeModule.java
@@ -14,9 +14,11 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import org.json.JSONObject;
 import org.json.JSONException;
@@ -359,19 +361,29 @@ public class AmplitudeReactNativeModule extends ReactContextBaseJavaModule {
         AmplitudeClient client = Amplitude.getInstance(instanceName);
         synchronized (client) {
             client.enableLogging(enableLogging);
+
+            if (enableLogging) {
+                client.setLogCallback(new AmplitudeLogCallback() {
+                    @Override
+                    public void onError(String tag, String message) {
+                        WritableNativeMap payload = new WritableNativeMap();
+                        payload.putString("tag", tag);
+                        payload.putString("message", message);
+
+                        reactContext
+                            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                            .emit(
+                                "AmplitudeLogError",
+                                payload
+                            );
+                    }
+                });
+            } else {
+                client.setLogCallback(null);
+            }
+
             promise.resolve(true);
         }
-    }
-
-    @ReactMethod
-    public void setLogCallback(String instanceName, Callback logCallback) {
-        AmplitudeClient client = Amplitude.getInstance(instanceName);
-        client.setLogCallback(new AmplitudeLogCallback() {
-            @Override
-            public void onError(String tag, String message) {
-              logCallback.invoke(tag, message);
-              }
-        });
     }
 
     @ReactMethod

--- a/src/index.ts
+++ b/src/index.ts
@@ -483,15 +483,15 @@ export class Amplitude {
   }
 
   /**
-   * Set log callback, it can help read and collect error message from sdk. The call back function like the following format
-   * (tag: string, message: string) => {
+   * Add log callback, it can help read and collect error message from sdk. The call back function like the following format
+   * ({ tag, message }: { tag: string, message: string }) => {
    *  //implement your own logic
    * }
    *
    * @param callback
    */
 
-  setLogCallback(callback: (error: AmplitudeLogError) => void): EmitterSubscription {
+  addLogCallback(callback: (error: AmplitudeLogError) => void): EmitterSubscription {
     return this._nativeEventEmitter.addListener("AmplitudeLogError", callback);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { NativeModules } from 'react-native';
+import { NativeModules, NativeEventEmitter, EmitterSubscription } from 'react-native';
 
 import { Constants } from './constants';
 import { Identify, IdentifyPayload, IdentifyOperation } from './identify';
@@ -13,6 +13,7 @@ import {
   SpecialEventType,
   Plan,
   IngestionMetadata,
+  AmplitudeLogError
 } from './types';
 import { MiddlewareRunner } from './middlewareRunner';
 
@@ -39,12 +40,15 @@ export class Amplitude {
   private static _defaultInstanceName = '$default_instance';
   instanceName: string;
   private readonly _middlewareRunner: MiddlewareRunner;
+  private readonly _nativeEventEmitter: NativeEventEmitter;
 
   private constructor(instanceName: string) {
     this.instanceName = instanceName;
     this._middlewareRunner = new MiddlewareRunner();
     this._setLibraryName(Constants.packageSourceName);
     this._setLibraryVersion(Constants.packageVersion);
+
+    this._nativeEventEmitter = new NativeEventEmitter(NativeModules.AmplitudeReactNative);
   }
 
   static getInstance(
@@ -487,8 +491,8 @@ export class Amplitude {
    * @param callback
    */
 
-  setLogCallback(callback: Function): void {
-    AmplitudeReactNative.setLogCallback(this.instanceName, callback);
+  setLogCallback(callback: (error: AmplitudeLogError) => void): EmitterSubscription {
+    return this._nativeEventEmitter.addListener("AmplitudeLogError", callback);
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { EmitterSubscription } from 'react-native';
 import { IdentifyPayload } from './identify';
 
 type PropertiesObject = Record<string, any>;
@@ -11,6 +12,8 @@ type RevenueProperties = {
   receiptSignature?: string;
   eventProperties?: PropertiesObject;
 };
+
+export type AmplitudeLogError = { tag: string; massage: string };
 
 export interface AmplitudeReactNativeModule {
   initialize(instanceName: string, apiKey: string): Promise<boolean>;
@@ -93,7 +96,7 @@ export interface AmplitudeReactNativeModule {
   setPlan(instanceName: string, plan: Plan): Promise<boolean>;
   setIngestionMetadata(instanceName: string, ingestionMetadata: IngestionMetadata): Promise<boolean>;
   enableLogging(instanceName: string, enableLogging: boolean): Promise<boolean>;
-  setLogCallback(instanceName: string, callback: Function): void;
+  setLogCallback(instanceName: string, callback: (error: AmplitudeLogError) => void): EmitterSubscription;
   setLogLevel(instanceName: string, logLevel: number): Promise<boolean>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ type RevenueProperties = {
   eventProperties?: PropertiesObject;
 };
 
-export type AmplitudeLogError = { tag: string; massage: string };
+export type AmplitudeLogError = { tag: string; message: string };
 
 export interface AmplitudeReactNativeModule {
   initialize(instanceName: string, apiKey: string): Promise<boolean>;
@@ -96,7 +96,7 @@ export interface AmplitudeReactNativeModule {
   setPlan(instanceName: string, plan: Plan): Promise<boolean>;
   setIngestionMetadata(instanceName: string, ingestionMetadata: IngestionMetadata): Promise<boolean>;
   enableLogging(instanceName: string, enableLogging: boolean): Promise<boolean>;
-  setLogCallback(instanceName: string, callback: (error: AmplitudeLogError) => void): EmitterSubscription;
+  addLogCallback(instanceName: string, callback: (error: AmplitudeLogError) => void): EmitterSubscription;
   setLogLevel(instanceName: string, logLevel: number): Promise<boolean>;
 }
 


### PR DESCRIPTION
In the version 2.13.0 an error callback was introduced with the PR - https://github.com/amplitude/Amplitude-ReactNative/pull/131

It uses Callback as a parameter for native method on Android, but actually the callback [can't be called more than once](https://github.com/facebook/react-native/issues/6300). ([Source code](https://github.com/facebook/react-native/blob/8bd3edec88148d0ab1f225d2119435681fbbba33/ReactAndroid/src/main/java/com/facebook/react/bridge/CallbackImpl.java#L25-L30))

To fix this, instead of calling a callback, I emit an event, and allow to subscribe for it, using `NativeEventEmitter`.