### PR TITLE
fix: event emitter warning

### DIFF
--- a/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeModule.java
+++ b/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeModule.java
@@ -395,6 +395,15 @@ public class AmplitudeReactNativeModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void addListener(String eventName) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+    @ReactMethod
+    public void removeListeners(Integer count) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
     private Revenue createRevenue(JSONObject properties) {
         Revenue revenue = new Revenue();
         try {

--- a/example/src/utils/amplitude.tsx
+++ b/example/src/utils/amplitude.tsx
@@ -15,9 +15,6 @@ const initAmplitude = (): Amplitude => {
     versionId: 'example-version-id',
   });
   amplitudeInstance.enableLogging(true);
-  amplitudeInstance.setLogCallback((tag: string, message: string) => {
-    console.log(`${tag}: ${message}`);
-  });
   amplitudeInstance.setLogLevel(2);
   amplitudeInstance.addEventMiddleware((payload, next) => {
     const { event, extra } = payload;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-import { NativeModules, NativeEventEmitter, EmitterSubscription } from 'react-native';
+import {
+  NativeModules,
+  NativeEventEmitter,
+  EmitterSubscription,
+} from 'react-native';
 
 import { Constants } from './constants';
 import { Identify, IdentifyPayload, IdentifyOperation } from './identify';
@@ -13,7 +17,7 @@ import {
   SpecialEventType,
   Plan,
   IngestionMetadata,
-  AmplitudeLogError
+  AmplitudeLogError,
 } from './types';
 import { MiddlewareRunner } from './middlewareRunner';
 
@@ -48,7 +52,9 @@ export class Amplitude {
     this._setLibraryName(Constants.packageSourceName);
     this._setLibraryVersion(Constants.packageVersion);
 
-    this._nativeEventEmitter = new NativeEventEmitter(NativeModules.AmplitudeReactNative);
+    this._nativeEventEmitter = new NativeEventEmitter(
+      NativeModules.AmplitudeReactNative,
+    );
   }
 
   static getInstance(
@@ -465,7 +471,10 @@ export class Amplitude {
    * @param ingestionMetadata IngestionMetadata object
    */
   setIngestionMetadata(ingestionMetadata: IngestionMetadata): Promise<boolean> {
-    return AmplitudeReactNative.setIngestionMetadata(this.instanceName, ingestionMetadata);
+    return AmplitudeReactNative.setIngestionMetadata(
+      this.instanceName,
+      ingestionMetadata,
+    );
   }
 
   addEventMiddleware(middleware: Middleware): Amplitude {
@@ -491,8 +500,10 @@ export class Amplitude {
    * @param callback
    */
 
-  addLogCallback(callback: (error: AmplitudeLogError) => void): EmitterSubscription {
-    return this._nativeEventEmitter.addListener("AmplitudeLogError", callback);
+  addLogCallback(
+    callback: (error: AmplitudeLogError) => void,
+  ): EmitterSubscription {
+    return this._nativeEventEmitter.addListener('AmplitudeLogError', callback);
   }
 
   /**


### PR DESCRIPTION
I'm able to reproduce the issue 
 WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.
 WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.
The solution is based on those research:
https://stackoverflow.com/a/69650217/11969222
https://github.com/react-native-netinfo/react-native-netinfo/issues/486#issuecomment-902029567
