### PR TITLE
fix: NativeEventEmitter warning on iOS

### DIFF
--- a/ios/AmplitudeReactNative.m
+++ b/ios/AmplitudeReactNative.m
@@ -72,4 +72,12 @@ RCT_EXTERN_METHOD(setLogCallback:(NSString *)instanceName callback:(RCTResponseS
 
 RCT_EXTERN_METHOD(setLogLevel:(NSString *)instanceName logLevel:(NSInteger *)logLevel resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXPORT_METHOD(addListener:(NSString *)eventName) {
+  // Keep: Required for RN built in Event Emitter Calls.
+}
+
+RCT_EXPORT_METHOD(removeListeners:(NSInteger)count) {
+  // Keep: Required for RN built in Event Emitter Calls.
+}
+
 @end


### PR DESCRIPTION
#149 fixed the warning on Android but did not include a fix for iOS. This PR is the iOS fix.

Before: launch app and get console warnings

After: launch app with no console warnings