### PR TITLE
fix: React Native 0.72 deprecation warning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,8 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+    namespace "com.amplitude.reactnative"
+
     compileSdkVersion safeExtGet('compileSdkVersion', 29)
     buildToolsVersion safeExtGet('buildToolsVersion', '29.0.2')
     defaultConfig {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.amplitude.reactnative">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
React Native 0.72 has update gradle things and has the following warning

```
> Task :amplitude_analytics-react-native:processDebugManifest
package="com.amplitude.reactnative" found in source AndroidManifest.xml: /home/johnf/work/gladly/mobile/node_modules/@amplitude/analytics-react-native/android/src/main/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
```