### PR TITLE
Fix: Add package name to the Android manifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest package="com.amplitude.reactnative" xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
Getting this error when running `pod update` after upgrading from 2.17.0 to 2.17.2:

```
error Failed to build the app: No package name found. Found errors in /Users/xxx/node_modules/@amplitude/react-native/android/src/main/AndroidManifest.xml.

[!] Invalid `Podfile` file: unexpected token at 'info Run CLI with --verbose flag for more details.
'.

 #  from /Users/xxx/ios/Podfile:8
 #  -------------------------------------------
 #  target 'MyApp' do
 >    config = use_native_modules!
 #  
 #  -------------------------------------------
```

Our Podfile is identical to [this one](https://github.com/react-native-community/rn-diff-purge/blob/version/0.70.12/RnDiffApp/ios/Podfile).

The error goes away when we downgrade back to 2.17.0 -- or if we add a package name to Amplitude-ReactNative's manifest.